### PR TITLE
fixing logical OR

### DIFF
--- a/src/zufall.c
+++ b/src/zufall.c
@@ -100,7 +100,7 @@ int einsk(int k)
   if (k==1){return 1;}
   int zuf;
 	zuf=floor((double)(k)*nulleins()+1);
-	if(zuf>k|zuf<1)
+	if(zuf>k||zuf<1)
 	{
 	  zuf=einsk(k);
 	}


### PR DESCRIPTION
This should fix the failing Appveyor CI tests on Neuroconductor for R 3.5. The warning that generates the failure is
`* checking whether package 'dcemriS4' can be installed ... WARNING
Found the following significant warnings:
  zufall.c:103:8: warning: suggest parentheses around comparison in operand of '|' [-Wparentheses]
`

Full log can be found here: https://ci.appveyor.com/project/neuroconductor/dcemris4/build/job/ob15r7rt5oyo4mae